### PR TITLE
Add Custom Worlds Support, Fix Pressure Plates, Add Interaction Timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>dev.demeng</groupId>
   <artifactId>commandbuttons</artifactId>
-  <version>5.0.1</version>
+  <version>5.0.2</version>
   <packaging>jar</packaging>
 
   <name>CommandButtons</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>dev.demeng</groupId>
   <artifactId>commandbuttons</artifactId>
-  <version>5.0.0</version>
+  <version>5.0.1</version>
   <packaging>jar</packaging>
 
   <name>CommandButtons</name>

--- a/src/main/java/dev/demeng/commandbuttons/CommandButtons.java
+++ b/src/main/java/dev/demeng/commandbuttons/CommandButtons.java
@@ -100,11 +100,6 @@ public final class CommandButtons extends BasePlugin {
     getLogger().info("Registering listeners...");
     Registerer.registerListener(new ButtonListener(this));
 
-    TaskUtils.delay(task -> {
-      getLogger().info("Loading command buttons...");
-      buttonsManager = new ButtonsManager(this);
-    }, 5L);
-
     getLogger().info("Loading metrics...");
     loadMetrics();
 
@@ -114,6 +109,11 @@ public final class CommandButtons extends BasePlugin {
     ChatUtils.console("&aCommandButtons v" + Common.getVersion()
         + " by Demeng has been enabled in "
         + (System.currentTimeMillis() - startTime) + " ms.");
+
+    TaskUtils.delay(task -> {
+      buttonsManager = new ButtonsManager(this);
+      getLogger().info("Loaded " + buttonsManager.getButtons().size() + " command button(s).");
+    }, 5L);
   }
 
   @Override

--- a/src/main/java/dev/demeng/commandbuttons/CommandButtons.java
+++ b/src/main/java/dev/demeng/commandbuttons/CommandButtons.java
@@ -89,9 +89,6 @@ public final class CommandButtons extends BasePlugin {
     getLogger().info("Initializing base settings...");
     updateBaseSettings();
 
-    getLogger().info("Loading command buttons...");
-    buttonsManager = new ButtonsManager(this);
-
     getLogger().info("Hooking into Vault and economy plugin...");
     if (!hookEconomy()) {
       getLogger().warning("Vault and/or economy plugin not found! Skipping...");
@@ -102,6 +99,11 @@ public final class CommandButtons extends BasePlugin {
 
     getLogger().info("Registering listeners...");
     Registerer.registerListener(new ButtonListener(this));
+
+    TaskUtils.delay(task -> {
+      getLogger().info("Loading command buttons...");
+      buttonsManager = new ButtonsManager(this);
+    }, 5L);
 
     getLogger().info("Loading metrics...");
     loadMetrics();

--- a/src/main/java/dev/demeng/commandbuttons/listeners/ButtonListener.java
+++ b/src/main/java/dev/demeng/commandbuttons/listeners/ButtonListener.java
@@ -60,6 +60,13 @@ public class ButtonListener implements Listener {
       return;
     }
 
+    final CommandButton button = i.getButtonsManager()
+        .getButtonByLocation(e.getClickedBlock().getLocation());
+
+    if (button == null) {
+      return;
+    }
+
     if (lastInteracted.getOrDefault(e.getPlayer(), 0L) + TIMEOUT >= System.currentTimeMillis()) {
       e.setCancelled(true);
       return;
@@ -67,13 +74,8 @@ public class ButtonListener implements Listener {
 
     lastInteracted.put(e.getPlayer(), System.currentTimeMillis());
 
-    final CommandButton button = i.getButtonsManager()
-        .getButtonByLocation(e.getClickedBlock().getLocation());
-
-    if (button != null) {
-      // Cancel event if button use is unsuccessful.
-      e.setCancelled(!button.use(e.getPlayer()));
-    }
+    // Cancel event if button use is unsuccessful.
+    e.setCancelled(!button.use(e.getPlayer()));
   }
 
   @EventHandler(priority = EventPriority.MONITOR)


### PR DESCRIPTION
• Delayed button loading until after all other plugins have loaded to ensure compatibility with custom world plugins such as Multiverse.
• Fixed pressure plate (physical) interactions not working on versions 1.9 and higher.
• Added a 500-millisecond timeout between attempted button interactions to prevent spam when holding down a mouse button or staying on a pressure plate.