### PR TITLE
Add support for item frames

### DIFF
--- a/src/main/java/dev/demeng/commandbuttons/commands/CommandButtonsCmd.java
+++ b/src/main/java/dev/demeng/commandbuttons/commands/CommandButtonsCmd.java
@@ -119,9 +119,17 @@ public class CommandButtonsCmd {
       return;
     }
 
+    // Test for item frame
+    Location finalLocation = targetBlock.getLocation();
+    final Location blockFaceLocation = Utils.getBlockFaceLocation(p);
+
+    if (blockFaceLocation != null && Utils.isItemFrame(blockFaceLocation)) {
+      finalLocation = blockFaceLocation;
+    }
+
     final CommandButton button = new CommandButton(
         id,
-        new ArrayList<>(Collections.singletonList(targetBlock.getLocation())),
+        new ArrayList<>(Collections.singletonList(finalLocation)),
         "none",
         true,
         3000L,

--- a/src/main/java/dev/demeng/commandbuttons/menus/ButtonMenu.java
+++ b/src/main/java/dev/demeng/commandbuttons/menus/ButtonMenu.java
@@ -27,6 +27,7 @@ package dev.demeng.commandbuttons.menus;
 import dev.demeng.commandbuttons.CommandButtons;
 import dev.demeng.commandbuttons.model.CommandButton;
 import dev.demeng.commandbuttons.util.LocationSerializer;
+import dev.demeng.commandbuttons.util.Utils;
 import dev.demeng.pluginbase.Common;
 import dev.demeng.pluginbase.Time;
 import dev.demeng.pluginbase.Time.DurationFormatter;
@@ -75,8 +76,10 @@ public class ButtonMenu extends Menu {
     lore.add("&6Current:");
 
     for (Location loc : button.getLocations()) {
+      final String blockName = (Utils.isItemFrame(loc)) ? "Item Frame" : loc.getBlock().getType().name();
+
       lore.add("&f- " + LocationSerializer.serialize(loc)
-          + " (" + loc.getBlock().getType().name() + ")");
+          + " (" + blockName + ")");
     }
 
     lore.add("");

--- a/src/main/java/dev/demeng/commandbuttons/menus/ButtonsListMenu.java
+++ b/src/main/java/dev/demeng/commandbuttons/menus/ButtonsListMenu.java
@@ -92,6 +92,9 @@ public class ButtonsListMenu extends PagedMenu {
         if (!Utils.isAir(loc.getBlock())) {
           stack = new ItemStack(loc.getBlock().getType());
           break;
+        } else if (Utils.isItemFrame(loc)) {
+          stack = new ItemStack(Material.ITEM_FRAME);
+          break;
         }
       }
 
@@ -104,8 +107,10 @@ public class ButtonsListMenu extends PagedMenu {
       lore.add("&6Locations");
 
       for (Location loc : button.getLocations()) {
+        final String blockName = (Utils.isItemFrame(loc)) ? "Item Frame" : loc.getBlock().getType().name();
+
         lore.add("&f- " + LocationSerializer.serialize(loc)
-            + " (" + loc.getBlock().getType().name() + ")");
+            + " (" + blockName + ")");
       }
 
       lore.add("");

--- a/src/main/java/dev/demeng/commandbuttons/util/Utils.java
+++ b/src/main/java/dev/demeng/commandbuttons/util/Utils.java
@@ -25,8 +25,14 @@
 package dev.demeng.commandbuttons.util;
 
 import dev.demeng.pluginbase.Common;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.ItemFrame;
+import org.bukkit.entity.Player;
+
+import java.util.List;
 
 /**
  * General utilities.
@@ -42,5 +48,38 @@ public class Utils {
   public static boolean isAir(Block block) {
     return block == null || block.getType() == Material.AIR
         || (Common.isServerVersionAtLeast(13) && block.getType().isAir());
+  }
+
+  /**
+   * Gets the Location of the BlockFace of the block the player is currently targeting.
+   *
+   * @param player the player whose targeted blocks BlockFace is to be checked.
+   * @return the Location of the BlockFace of the targeted block, or null if the targeted block is non-occluding.
+   */
+  public static Location getBlockFaceLocation(Player player) {
+    List<Block> lastTwoTargetBlocks = player.getLastTwoTargetBlocks(null, 100);
+    if (lastTwoTargetBlocks.size() != 2 || !lastTwoTargetBlocks.get(1).getType().isOccluding()) return null;
+    Block targetBlock = lastTwoTargetBlocks.get(1);
+    Block adjacentBlock = lastTwoTargetBlocks.get(0);
+
+    return adjacentBlock.getLocation();
+  }
+
+  /**
+   * Checks if the provided block has an item frame occupying it.
+   *
+   * @param location the location to be checked
+   * @return true or false
+   */
+  public static Boolean isItemFrame(Location location) {
+    for (Entity e : location.getChunk().getEntities()) {
+      if (e instanceof ItemFrame
+              && (e.getLocation().getBlockX() == location.getBlockX())
+              && (e.getLocation().getBlockY() == location.getBlockY())
+              && (e.getLocation().getBlockZ() == location.getBlockZ())) {
+        return true;
+      }
+    }
+    return false;
   }
 }


### PR DESCRIPTION
This adds support for using item frames as command buttons. Also will prevent rotation if the `"ITEM_FRAME"` is in the `disable-interaction` list in the config.

I'm still new to the java language and Minecraft development, so let me know if I've made any mistakes or if there are better ways to accomplish these features. Thanks!